### PR TITLE
Fix compatibly with Django-Cachalot

### DIFF
--- a/django_elastipymemcache/client.py
+++ b/django_elastipymemcache/client.py
@@ -2,4 +2,37 @@ from pymemcache.client.hash import HashClient
 
 
 class Client(HashClient):
-    pass
+    def get_many(self, keys, gets=False, *args, **kwargs):
+        client_batches = {}
+        end = {}
+
+        for key in keys:
+            client = self._get_client(key)
+
+            if client is None:
+                continue
+
+            if client.server not in client_batches:
+                client_batches[client.server] = []
+
+            client_batches[client.server].append(key)
+
+        for server, keys in client_batches.items():
+            client = self.clients['%s:%s' % server]
+            new_args = list(args)
+            new_args.insert(0, keys)
+
+            if gets:
+                get_func = client.gets_many
+            else:
+                get_func = client.get_many
+
+            result = self._safely_run_func(
+                client,
+                get_func, {}, *new_args, **kwargs
+            )
+            end.update(result)
+
+        return end
+
+    get_multi = get_many


### PR DESCRIPTION
Fix compatibly with Django-Cachalot
    
When pymemcache server does not found at <https://github.com/pinterest/pymemcache/blob/master/pymemcache/client/hash.py#L277-L280>.
    
Current implementation returns `{'key': False}` if server does not found.
But this return value would raise following exception at django-cachalot.
    
```
File "/tmp/app/lib/python3.6/site-packages/cachalot/monkey_patch.py", line 85, in inner
      cache_key, table_cache_keys)
File "/tmp/app/lib/python3.6/site-packages/cachalot/monkey_patch.py", line 51, in _get_result_or_execute_query
      timestamp, result = data.pop(cache_key)
TypeError: 'bool' object is not iterable
```
    
https://github.com/BertrandBordage/django-cachalot/blob/master/cachalot/monkey_patch.py#L39-L45
    
So, this patch ignore if server does not found, just return `{}` to avoid raise TypeError.

Please review this PR and very pleasure to give me advices.