### PR TITLE
Fix ignore pymemcache's get_many returns False value

### DIFF
--- a/django_elastipymemcache/client.py
+++ b/django_elastipymemcache/client.py
@@ -6,6 +6,6 @@ class Client(HashClient):
         # pymemcache's HashClient may returns {'key': False}
         end = super(Client, self).get_many(keys, gets, args, kwargs)
 
-        return {key: end[key] for key in end if end[key]}
+        return {key: end.get(key) for key in end if end.get(key)}
 
     get_multi = get_many

--- a/django_elastipymemcache/client.py
+++ b/django_elastipymemcache/client.py
@@ -2,4 +2,10 @@ from pymemcache.client.hash import HashClient
 
 
 class Client(HashClient):
-    pass
+    def get_many(self, keys, gets=False, *args, **kwargs):
+        # pymemcache's HashClient may returns {'key': False}
+        end = super(Client, self).get_many(keys, gets, args, kwargs)
+
+        return {key: end[key] for key in end if end[key]}
+
+    get_multi = get_many

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -99,3 +99,49 @@ def test_invalidate_cache(get_cluster_info):
         pass
     eq_(backend._cache.get.call_count, 2)
     eq_(get_cluster_info.call_count, 3)
+
+
+@patch('django.conf.settings', global_settings)
+@patch('django_elastipymemcache.memcached.get_cluster_info')
+def test_client_get_many(get_cluster_info):
+    from django_elastipymemcache.memcached import ElastiPyMemCache
+
+    servers = [('h1', 0), ('h2', 0)]
+    get_cluster_info.return_value = {
+        'nodes': servers
+    }
+
+    backend = ElastiPyMemCache('h:0', {})
+    ret = backend.get_many(['key1'])
+    eq_(ret, {})
+
+    # When server does not found...
+    with patch('pymemcache.client.hash.HashClient._get_client') as p:
+        p.return_value = None
+        ret = backend.get_many(['key2'])
+        eq_(ret, {})
+
+    with patch('django_elastipymemcache.client.Client.get_many'):
+        with patch('pymemcache.client.hash.HashClient._safely_run_func') as p2:
+            p2.return_value = {
+                ':1:key3': 1509111630.048594
+            }
+
+            ret = backend.get_many(['key3'])
+            eq_(ret, {'key3': 1509111630.048594})
+
+    # If False value is included, ignore it.
+    with patch('pymemcache.client.hash.HashClient.get_many') as p:
+        p.return_value = {
+            ':1:key1': 1509111630.048594,
+            ':1:key2': False,
+            ':1:key3': 1509111630.058594,
+        }
+        ret = backend.get_many(['key1', 'key2', 'key3'])
+        eq_(
+            ret,
+            {
+                'key1': 1509111630.048594,
+                'key3': 1509111630.058594
+            },
+        )

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -121,14 +121,14 @@ def test_client_get_many(get_cluster_info):
         ret = backend.get_many(['key2'])
         eq_(ret, {})
 
-    with patch('django_elastipymemcache.client.Client.get_many'):
-        with patch('pymemcache.client.hash.HashClient._safely_run_func') as p2:
-            p2.return_value = {
-                ':1:key3': 1509111630.048594
-            }
+    with patch('django_elastipymemcache.client.Client.get_many'), \
+            patch('pymemcache.client.hash.HashClient._safely_run_func') as p2:
+        p2.return_value = {
+            ':1:key3': 1509111630.048594
+        }
 
-            ret = backend.get_many(['key3'])
-            eq_(ret, {'key3': 1509111630.048594})
+        ret = backend.get_many(['key3'])
+        eq_(ret, {'key3': 1509111630.048594})
 
     # If False value is included, ignore it.
     with patch('pymemcache.client.hash.HashClient.get_many') as p:
@@ -143,5 +143,19 @@ def test_client_get_many(get_cluster_info):
             {
                 'key1': 1509111630.048594,
                 'key3': 1509111630.058594
+            },
+        )
+
+    with patch('pymemcache.client.hash.HashClient.get_many') as p:
+        p.return_value = {
+            ':1:key1': None,
+            ':1:key2': 1509111630.048594,
+            ':1:key3': False,
+        }
+        ret = backend.get_many(['key1', 'key2', 'key3'])
+        eq_(
+            ret,
+            {
+                'key2': 1509111630.048594,
             },
         )


### PR DESCRIPTION
2nd try ☺️ 

In some case, pymemcache returns {'key': False} if client does not found.

It raises exception at Django-Cachalot.

Django-Cachalot's author said like following.

>get_many should not contain a key that's not in the cache, as stated in Django.

So try to imprements get_many method and ignore if False were included.

Please review this and pleasure to give me advices.

Thank you.