### PR TITLE
Upgrade to Django 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,7 @@ python:
   - 3.8
 cache: pip
 env:
-  - DJANGO=2.2
-  - DJANGO=3.0
-  - DJANGO=3.1
+  - DJANGO=3.2
   - DJANGO=dev
 
 matrix:
@@ -38,6 +36,6 @@ deploy:
     repo: harikitech/django-elastipymemcache
     tags: true
     python: 3.8
-    condition: "$DJANGO = 3.0"
+    condition: "$DJANGO = 3.2"
 notifications:
   email: false

--- a/django_elastipymemcache/client.py
+++ b/django_elastipymemcache/client.py
@@ -26,10 +26,7 @@ class ConfigurationEndpointClient(Client):
         nodes = []
         for raw_node in raw_nodes.split(b' '):
             host, ip, port = raw_node.split(b'|')
-            nodes.append('{host}:{port}'.format(
-                host=smart_text(ip or host),
-                port=int(port)
-            ))
+            nodes.append((smart_text(ip or host), int(port)))
         return {
             'version': int(raw_version),
             'nodes': nodes,
@@ -69,11 +66,9 @@ class ConfigurationEndpointClient(Client):
                 logger.warn('Failed to get cluster: %s', e)
                 return {
                     'version': None,
-                    'nodes': [
-                        '{host}:{port:d}'.format(
-                            host=self.server[0],
-                            port=int(self.server[1]),
-                        ),
-                    ]
+                    'nodes': [(
+                        self.server[0],
+                        int(self.server[1]),
+                    )]
                 }
             raise

--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,8 @@ setup(
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',
-        'Framework :: Django :: 2.2',
-        'Framework :: Django :: 3.0',
-        'Framework :: Django :: 3.1',
+        'Framework :: Django',
+        'Framework :: Django :: 3.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
@@ -36,7 +35,7 @@ setup(
     packages=find_packages(exclude=('tests',)),
     include_package_data=True,
     install_requires=[
-        'django-pymemcache>=1.0',
-        'Django>=2.2',
+        'pymemcache==3.3.0',
+        'Django>=3.2',
     ],
 )

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -27,33 +27,29 @@ def test_split_servers(get_cluster_info):
     get_cluster_info.return_value = {
         'nodes': servers
     }
-    backend._lib.Client = Mock()
+    backend._class = Mock()
     assert backend._cache
     get_cluster_info.assert_called()
-    backend._lib.Client.assert_called_once_with(
-        servers,
-        ignore_exc=True,
-    )
+    backend._class.assert_called_once()
+    eq_(backend._class.call_args[0], (servers,))
 
 
 @patch.object(ConfigurationEndpointClient, 'get_cluster_info')
 def test_node_info_cache(get_cluster_info):
     from django_elastipymemcache.backend import ElastiPymemcache
-    servers = ['h1:0', 'h2:0']
+    servers = [('h1', 0), ('h2', 0)]
     get_cluster_info.return_value = {
         'nodes': servers
     }
 
     backend = ElastiPymemcache('h:0', {})
-    backend._lib.Client = Mock()
+    backend._class = Mock()
     backend.set('key1', 'val')
     backend.get('key1')
     backend.set('key2', 'val')
     backend.get('key2')
-    backend._lib.Client.assert_called_once_with(
-        servers,
-        ignore_exc=True,
-    )
+    backend._class.assert_called_once()
+    eq_(backend._class.call_args[0], (servers,))
     eq_(backend._cache.get.call_count, 2)
     eq_(backend._cache.set.call_count, 2)
 
@@ -65,19 +61,19 @@ def test_failed_to_connect_servers(get_cluster_info):
     from django_elastipymemcache.backend import ElastiPymemcache
     backend = ElastiPymemcache('h:0', {})
     get_cluster_info.side_effect = OSError()
-    eq_(backend.get_cluster_nodes(), [])
+    eq_(backend.client_servers, [])
 
 
 @patch.object(ConfigurationEndpointClient, 'get_cluster_info')
 def test_invalidate_cache(get_cluster_info):
     from django_elastipymemcache.backend import ElastiPymemcache
-    servers = ['h1:0', 'h2:0']
+    servers = [('h1', 0), ('h2', 0)]
     get_cluster_info.return_value = {
         'nodes': servers
     }
 
     backend = ElastiPymemcache('h:0', {})
-    backend._lib.Client = Mock()
+    # backend._class = Mock()
     assert backend._cache
     backend._cache.get = Mock()
     backend._cache.get.side_effect = Exception()
@@ -85,14 +81,17 @@ def test_invalidate_cache(get_cluster_info):
         backend.get('key1', 'val')
     except Exception:
         pass
-    #  invalidate cached client
-    container = getattr(backend, '_local', backend)
-    container._client = None
+    # This should have removed the _cache instance
+    assert '_cache' not in backend.__dict__
+    # Again
+    backend._cache.get = Mock()
+    backend._cache.get.side_effect = Exception()
     try:
         backend.get('key1', 'val')
     except Exception:
         pass
-    eq_(backend._cache.get.call_count, 2)
+    assert '_cache' not in backend.__dict__
+    assert backend._cache
     eq_(get_cluster_info.call_count, 3)
 
 
@@ -100,7 +99,7 @@ def test_invalidate_cache(get_cluster_info):
 def test_client_add(get_cluster_info):
     from django_elastipymemcache.backend import ElastiPymemcache
 
-    servers = ['h1:0', 'h2:0']
+    servers = [('h1', 0), ('h2', 0)]
     get_cluster_info.return_value = {
         'nodes': servers
     }
@@ -114,7 +113,7 @@ def test_client_add(get_cluster_info):
 def test_client_delete(get_cluster_info):
     from django_elastipymemcache.backend import ElastiPymemcache
 
-    servers = ['h1:0', 'h2:0']
+    servers = [('h1', 0), ('h2', 0)]
     get_cluster_info.return_value = {
         'nodes': servers
     }
@@ -131,7 +130,7 @@ def test_client_delete(get_cluster_info):
 def test_client_get_many(get_cluster_info):
     from django_elastipymemcache.backend import ElastiPymemcache
 
-    servers = ['h1:0', 'h2:0']
+    servers = [('h1', 0), ('h2', 0)]
     get_cluster_info.return_value = {
         'nodes': servers
     }
@@ -154,8 +153,8 @@ def test_client_get_many(get_cluster_info):
         ret = backend.get_many(['key3'])
         eq_(ret, {'key3': 1509111630.048594})
 
-    # If False value is included, ignore it.
-    with patch('pymemcache.client.hash.HashClient.get_many') as p:
+    # If False value is included, include it.
+    with patch('pymemcache.client.hash.HashClient.get_multi') as p:
         p.return_value = {
             ':1:key1': 1509111630.048594,
             ':1:key2': False,
@@ -166,20 +165,22 @@ def test_client_get_many(get_cluster_info):
             ret,
             {
                 'key1': 1509111630.048594,
+                'key2': False,
                 'key3': 1509111630.058594
             },
         )
 
-    with patch('pymemcache.client.hash.HashClient.get_many') as p:
+    # Even None is valid. Only key not found is not returned.
+    with patch('pymemcache.client.hash.HashClient.get_multi') as p:
         p.return_value = {
             ':1:key1': None,
             ':1:key2': 1509111630.048594,
-            ':1:key3': False,
         }
         ret = backend.get_many(['key1', 'key2', 'key3'])
         eq_(
             ret,
             {
+                'key1': None,
                 'key2': 1509111630.048594,
             },
         )
@@ -189,7 +190,7 @@ def test_client_get_many(get_cluster_info):
 def test_client_set_many(get_cluster_info):
     from django_elastipymemcache.backend import ElastiPymemcache
 
-    servers = ['h1:0', 'h2:0']
+    servers = [('h1', 0), ('h2', 0)]
     get_cluster_info.return_value = {
         'nodes': servers
     }
@@ -203,7 +204,7 @@ def test_client_set_many(get_cluster_info):
 def test_client_delete_many(get_cluster_info):
     from django_elastipymemcache.backend import ElastiPymemcache
 
-    servers = ['h1:0', 'h2:0']
+    servers = [('h1', 0), ('h2', 0)]
     get_cluster_info.return_value = {
         'nodes': servers
     }
@@ -217,7 +218,7 @@ def test_client_delete_many(get_cluster_info):
 def test_client_incr(get_cluster_info):
     from django_elastipymemcache.backend import ElastiPymemcache
 
-    servers = ['h1:0', 'h2:0']
+    servers = [('h1', 0), ('h2', 0)]
     get_cluster_info.return_value = {
         'nodes': servers
     }
@@ -231,7 +232,7 @@ def test_client_incr(get_cluster_info):
 def test_client_decr(get_cluster_info):
     from django_elastipymemcache.backend import ElastiPymemcache
 
-    servers = ['h1:0', 'h2:0']
+    servers = [('h1', 0), ('h2', 0)]
     get_cluster_info.return_value = {
         'nodes': servers
     }

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -18,8 +18,9 @@ EXAMPLE_RESPONSE = [
 ]
 
 
+@patch('socket.getaddrinfo', return_value=[range(5)])
 @patch('socket.socket')
-def test_get_cluster_info(socket):
+def test_get_cluster_info(socket, _):
     recv_bufs = collections.deque([
         b'VERSION 1.4.14\r\n',
     ] + EXAMPLE_RESPONSE)
@@ -27,15 +28,19 @@ def test_get_cluster_info(socket):
     client = socket.return_value
     client.recv.side_effect = lambda *args, **kwargs: recv_bufs.popleft()
     cluster_info = ConfigurationEndpointClient(('h', 0)).get_cluster_info()
-    eq_(cluster_info['nodes'], ['10.82.235.120:11211', '10.80.249.27:11211'])
+    eq_(cluster_info['nodes'], [
+            ('10.82.235.120', 11211),
+            ('10.80.249.27', 11211),
+        ])
     client.sendall.assert_has_calls([
         call(b'version\r\n'),
         call(b'config get cluster\r\n'),
     ])
 
 
+@patch('socket.getaddrinfo', return_value=[range(5)])
 @patch('socket.socket')
-def test_get_cluster_info_before_1_4_13(socket):
+def test_get_cluster_info_before_1_4_13(socket, _):
     recv_bufs = collections.deque([
         b'VERSION 1.4.13\r\n',
     ] + EXAMPLE_RESPONSE)
@@ -43,7 +48,10 @@ def test_get_cluster_info_before_1_4_13(socket):
     client = socket.return_value
     client.recv.side_effect = lambda *args, **kwargs: recv_bufs.popleft()
     cluster_info = ConfigurationEndpointClient(('h', 0)).get_cluster_info()
-    eq_(cluster_info['nodes'], ['10.82.235.120:11211', '10.80.249.27:11211'])
+    eq_(cluster_info['nodes'], [
+            ('10.82.235.120', 11211),
+            ('10.80.249.27', 11211),
+        ])
     client.sendall.assert_has_calls([
         call(b'version\r\n'),
         call(b'get AmazonElastiCache:cluster\r\n'),
@@ -51,21 +59,22 @@ def test_get_cluster_info_before_1_4_13(socket):
 
 
 @raises(MemcacheUnknownCommandError)
+@patch('socket.getaddrinfo', return_value=[range(5)])
 @patch('socket.socket')
-def test_no_configuration_protocol_support_with_errors(socket):
+def test_no_configuration_protocol_support_with_errors(socket, _):
     recv_bufs = collections.deque([
         b'VERSION 1.4.13\r\n',
         b'ERROR\r\n',
     ])
-
     client = socket.return_value
     client.recv.side_effect = lambda *args, **kwargs: recv_bufs.popleft()
     ConfigurationEndpointClient(('h', 0)).get_cluster_info()
 
 
 @raises(MemcacheUnknownError)
+@patch('socket.getaddrinfo', return_value=[range(5)])
 @patch('socket.socket')
-def test_cannot_parse_version(socket):
+def test_cannot_parse_version(socket, _):
     recv_bufs = collections.deque([
         b'VERSION 1.4.34\r\n',
         b'CONFIG cluster 0 147\r\n',
@@ -79,8 +88,9 @@ def test_cannot_parse_version(socket):
 
 
 @raises(MemcacheUnknownError)
+@patch('socket.getaddrinfo', return_value=[range(5)])
 @patch('socket.socket')
-def test_cannot_parse_nodes(socket):
+def test_cannot_parse_nodes(socket, _):
     recv_bufs = collections.deque([
         b'VERSION 1.4.34\r\n',
         b'CONFIG cluster 0 147\r\n',
@@ -93,8 +103,9 @@ def test_cannot_parse_nodes(socket):
     ConfigurationEndpointClient(('h', 0)).get_cluster_info()
 
 
+@patch('socket.getaddrinfo', return_value=[range(5)])
 @patch('socket.socket')
-def test_ignore_erros(socket):
+def test_ignore_erros(socket, _):
     recv_bufs = collections.deque([
         b'VERSION 1.4.34\r\n',
         b'fail\nfail\n\r\n',
@@ -107,4 +118,4 @@ def test_ignore_erros(socket):
         ('h', 0),
         ignore_cluster_errors=True,
     ).get_cluster_info()
-    eq_(cluster_info['nodes'], ['h:0'])
+    eq_(cluster_info['nodes'], [('h', 0)])

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,6 @@
 [tox]
 envlist =
-  py{36,37,38}-dj22,
-  py{36,37,38}-dj30,
-  py{36,37,38}-dj31,
+  py{36,37,38}-dj32,
   py{36,37,38}-djdev,
   flake8,
   isort,
@@ -11,28 +9,23 @@ envlist =
 
 [travis:env]
 DJANGO =
-  2.2: dj22
-  3.0: dj30
-  3.1: dj31
+  3.2: dj32
   dev: djdev
 
 [testenv]
 passenv = TOXENV CI TRAVIS TRAVIS_* CODECOV_*
 deps =
-  dj22: Django<2.3
-  dj30: Django<3.1
-  dj31: Django<3.2
-  django-pymemcache<2.0
+  dj32: Django<3.3
   djdev: https://github.com/django/django/archive/master.tar.gz
   -r{toxinidir}/requirements.txt
-  py38-dj31: codecov
+  py37-dj32: codecov
 setenv =
   PYTHONPATH = {toxinidir}
 commands =
   coverage run --source=django_elastipymemcache -m nose --verbose
-  py38-dj31: coverage report
-  py38-dj31: coverage xml
-  py38-dj31: codecov
+  py37-dj32: coverage report
+  py37-dj32: coverage xml
+  py37-dj32: codecov
 
 [testenv:flake8]
 basepython = python3.8


### PR DESCRIPTION
This is, IMO, the minimal change required for proper support Django>=3.2, fixing #170.

Note: No effort has been made to keep support of older Django versions -- none of them have more than a few months before EOL.