### PR TITLE
Use hatch-vcs

### DIFF
--- a/django_elastipymemcache/__init__.py
+++ b/django_elastipymemcache/__init__.py
@@ -1,1 +1,10 @@
-__version__ = "3.0.0"
+try:
+    from ._version import __version__, __version_tuple__
+except ImportError:
+    __version__ = "unknown"
+    __version_tuple__ = ()
+
+__all__ = [
+    "__version__",
+    "__version_tuple__",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = [
   "hatchling>=1.25",
+  "hatch-vcs>=0.5.0",
 ]
 build-backend = "hatchling.build"
 
@@ -117,7 +118,7 @@ plugins = [
 django_settings_module = "tests.settings"
 
 [tool.hatch.version]
-path = "django_elastipymemcache/__init__.py"
+source = "vcs"
 
 [tool.hatch.build.targets.sdist]
 include = [

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -2,6 +2,9 @@ def test_import_and_version() -> None:
     import django_elastipymemcache
 
     assert hasattr(django_elastipymemcache, "__version__")
+    assert django_elastipymemcache.__version__ != "unknown"
+    assert hasattr(django_elastipymemcache, "__version__tuple__")
+    assert django_elastipymemcache.__version_tuple__ != ()
 
 
 def test_backend_importable() -> None:


### PR DESCRIPTION
# About

- Dependabot can't get the version 🤔 
- https://github.com/harikitech/django-elastipymemcache/actions/runs/19154260598
- Use: [hatch-vcs · PyPI](https://pypi.org/project/hatch-vcs/)